### PR TITLE
Include necessary information to build WRF-CTSM

### DIFF
--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -19,11 +19,26 @@ To set `ESMFMKFILE`. Login to fram and
 
     [~/HOME]$ load module ESMF/same_version_as_in_config_compilers
   
-Set the environmental variable
+Set the path variable
 
     [~/HOME]$ export ESMFMKFILE=$EBROOTESMF/lib/esmf.mk
 
 Clear all loaded modules
 
     [~/HOME]$ module purge
+    
+## 3.4.1.3. Building WRF with CTSM
+
+```{discussion} NETCDF
+In addition to the decribed steps, it is necessary to set the path to the Fortran NetCDF on FRAM before running `./configure`.
+```
+Set the path variables
+
+    [~/HOME]$ export NETCDF=${EBROOTNETCDFMINFORTRAN}
+    [~/HOME]$ export NETCDF_classic=1    
+
+```{discussion} Compiling WRF
+Compiling WRF takes a long time. Therefore, you should put the compiling job into the background. If your conection to FRAM breaks the job will still run!
+```
+    [~/WRF-CTSM]$ nohup ./compile em_real 2>&1 > compile.log & 
     

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -49,8 +49,8 @@ The automatic creation of the configuration (option 19 is a good choice) fails t
 
 Change 
 
-    `DM_FC= mpiifort`
-    `DM_CC= mpiicc`
+    DM_FC= mpiifort
+    DM_CC= mpiicc
     
 and add `-gopenmp` to the end of the line which reads `LDFLAGS`.
 Because `jasper` is one of the compiler options you have to load two additional modules beforehand

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -35,7 +35,9 @@ In addition to the decribed steps, it is necessary to set the path to the Fortra
 Set the path variables
 
     [~/HOME]$ export NETCDF=${EBROOTNETCDFMINFORTRAN}
-    [~/HOME]$ export NETCDF_classic=1    
+    [~/HOME]$ export NETCDF_classic=1
+    
+When running `./configure` you will be asked for a set of compiler options [1-75]. A good choice is 15.
 
 ```{discussion} Compiling WRF
 Compiling WRF takes a long time. Therefore, you should put the compiling job into the background. If your conection to FRAM breaks the job will still run!

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -20,21 +20,10 @@ Special advices for the supported HPC machines at UiO are given in the following
 ```{discussion} ESMF
 A 3. party software (ESMF) is needed for coupling to WRF. 
 - The version required (currently >= 8.1.0, 2018-09-10) is only available on FRAM.
-- Update your dotcime to include ESMF ([experimental, checkout branch wrf_ctsm](https://github.com/ziu1986/dotcime)).
-- Building CTSM with LILAC requires the path variable `ESMFMKFILE` to be set beforehand.
+- Update or clone `dotcime` to include ESMF (commit 092d9f9).
 ```
-To set `ESMFMKFILE`. Login to fram and
+For building CTSM with LILAC the path variable `ESMFMKFILE` has to be set in `config_machines`. 
 
-    [~/HOME]$ load module ESMF/same_version_as_in_config_compilers
-  
-Set the path variable
-
-    [~/HOME]$ export ESMFMKFILE=$EBROOTESMF/lib/esmf.mk
-
-Clear all loaded modules
-
-    [~/HOME]$ module purge
-    
 ## 3.4.1.3. Building WRF with CTSM
 
 ```{discussion} NETCDF

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -61,6 +61,7 @@ Because `jasper` is one of the compiler options you have to load two additional 
 ## Example setpath script
 
 Reoccuring setting of environmental variables and loading of modules can be automated. We assume that you have set
+
 `export WORK=/cluster/work/users/${USER}`
 
 ```bash

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -1,3 +1,29 @@
 # WRF-CTSM 
 
-Here we will put our documentation which contains details for WRF-CTSM
+```{keypoints} Info
+A detailed documentation](https://escomp.github.io/ctsm-docs/versions/master/html/lilac/specific-atm-models/index.html)] about how to set up and run CTSM with WRF can be found in the original. 
+```
+
+Please follow the steps described there! 
+In the following, special advices for the supported HPC machines at UiO are given.
+
+## 3.4.1.2 Building CTSM
+
+```{discussion} ESMF
+A 3. party software (ESMF) is needed for coupling to WRF. 
+- The version required (currently >= 8.1.0, 2018-09-10) is only available on FRAM.
+- Update your dotcime to include ESMF ([experimental, checkout branch wrf_ctsm](https://github.com/ziu1986/dotcime)).
+- Building CTSM with LILAC requires the path variable `ESMFMKFILE` to be set beforehand.
+```
+To set `ESMFMKFILE`. Login to fram and
+
+    [~/HOME]$ load module ESMF/same_version_as_in_config_compilers
+  
+Set the environmental variable
+
+    [~/HOME]$ export ESMFMKFILE=$EBROOTESMF/lib/esmf.mk
+
+Clear all loaded modules
+
+    [~/HOME]$ module purge
+    

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -4,8 +4,16 @@
 A detailed documentation](https://escomp.github.io/ctsm-docs/versions/master/html/lilac/specific-atm-models/index.html)] about how to set up and run CTSM with WRF can be found in the original. 
 ```
 
-Please follow the steps described there! 
-In the following, special advices for the supported HPC machines at UiO are given.
+Please follow the steps described there!
+Special advices for the supported HPC machines at UiO are given in the following.
+
+```{discussion} Build directory
+- It is good practice to NOT build your software in the source directory.
+- Choose a build directory, e.g. in your home or project directory
+```
+    
+    [~/HOME]$ export CTSM_BUILD_DIRECTORY=~/ctsm_build_directory
+    
 
 ## 3.4.1.2 Building CTSM
 

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -87,3 +87,17 @@ module load libpng/1.6.37-GCCcore-10.3.0
 export WRF_GEOG_PATH=/cluster/shared/wrf/geog_wrfv4
 
 ```
+
+## 3.4.1.5. Run WPS Programs
+
+```{discussion} plotgrid_new.ncl
+To have a look at your created domain you need to load NCL.
+
+`module load NCL/6.6.2-intel-2018b`
+
+Because we are using a new version of NCL, `plotgrid.ncl` may not work.
+Note: `namelist.wps` has to be in your working directory! But you can call it from anywhere using its absolute path. 
+
+```
+
+    [WORK/cases] ncl ${WPS_ROOT}/util/plotgrid_new.ncl

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -58,3 +58,31 @@ Because `jasper` is one of the compiler options you have to load two additional 
     [~/WRF-CTSM/WPS] module load JasPer/2.0.28-GCCcore-10.3.0
     [~/WRF-CTSM/WPS] module load libpng/1.6.37-GCCcore-10.3.0
     
+## Example setpath script
+
+Reoccuring setting of environmental variables and loading of modules can be automated. We assume that you have set
+`export WORK=/cluster/work/users/${USER}`
+
+```bash
+# Location of your CTSM clone
+export CTSM_ROOT=~/WRF-CTSM/CTSM/
+# Location of your CTSM build
+export CTSM_BUILD_DIRECTORY=~/ctsm_build_directory
+# Load all modules which WRF and CTSM have in common
+source $CTSM_BUILD_DIR/ctsm_build_environment.sh
+# For building WRF
+export WRF_ROOT=$WORKSPACE/WRF-CTSM
+export WRF_CTSM_MKFILE=$CTSM_BUILD_DIR/bld/ctsm.mk
+export WRF_EM_CORE=1
+export WRF_DA_CORE=0
+export NETCDF=${EBROOTNETCDFMINFORTRAN}
+export NETCDF_classic=1
+# For building WPS
+export WPS_ROOT=$WORKSPACE/WPS
+export WRF_DIR=$WRF_ROOT
+module load JasPer/2.0.28-GCCcore-10.3.0
+module load libpng/1.6.37-GCCcore-10.3.0
+# For running WRF
+export WRF_GEOG_PATH=/cluster/shared/wrf/geog_wrfv4
+
+```

--- a/content/wrf-ctsm.md
+++ b/content/wrf-ctsm.md
@@ -41,3 +41,20 @@ Compiling WRF takes a long time. Therefore, you should put the compiling job int
 ```
     [~/WRF-CTSM]$ nohup ./compile em_real 2>&1 > compile.log & 
     
+## 3.4.1.4 Building WPS
+
+The automatic creation of the configuration (option 19 is a good choice) fails to recognize the compilers, therefore you have to make some changes in `configure.wps` manually.
+
+    [~/WRF-CTSM/WPS] nano configure.wps
+
+Change 
+
+    `DM_FC= mpiifort`
+    `DM_CC= mpiicc`
+    
+and add `-gopenmp` to the end of the line which reads `LDFLAGS`.
+Because `jasper` is one of the compiler options you have to load two additional modules beforehand
+    
+    [~/WRF-CTSM/WPS] module load JasPer/2.0.28-GCCcore-10.3.0
+    [~/WRF-CTSM/WPS] module load libpng/1.6.37-GCCcore-10.3.0
+    


### PR DESCRIPTION
An initial draft on how to set up WRF-CTSM on FRAM.
This also includes tips on ESMF setup and links to the experimental dotcime branch.

Related issues: MetOs-UiO#16 and MetOs-UiO#26