### PR TITLE
Add quick start page

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,18 +1,13 @@
-name: Spelling Erros Check
+name: Spelling Errors Check
 
 on: [push]
 
 jobs:
   build:
-    strategy:
-      max-parallel: 2
-      matrix:
-        os: [ubuntu-latest]
-      
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install dependencies
       run: curl -L https://git.io/misspell | bash
 

--- a/content/conf.py
+++ b/content/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "CTSM-Norway"
-copyright = "2021, CTSM-Norway team"
+copyright = "2022, CTSM-Norway team"
 author = "CTSM-Norway team"
 github_user = "MetOs-UiO"
 github_repo_name = "CTSM-Norway-Documentation"  # auto-detected from dirname if blank

--- a/content/get.md
+++ b/content/get.md
@@ -11,7 +11,7 @@ Throughout all this documentation we define some path variables:
 ## Supported machines
 This tutorial assumes that you are logged into one of the clusters of Sigma2. (See [here](https://metos-uio.github.io/CTSM-Norway-Documentation/prerequisite/#needed-accesses) for how to get cluster access). 
 
-Currently (June 2021), we support machine configurations for: 
+Currently (February 2022), we support machine configurations for: 
 -   saga (sigma2, Norway)
 -   fram (sigma2, Norway)
 
@@ -24,13 +24,17 @@ A user is a person that runs CTSM without modifying the source code. To get the 
     [~/HOME]$ git clone -b release-clm5.0 https://github.com/NordicESMhub/ctsm.git ${HOME}/ctsm_fates_emerald
 
 In this example, we are checking out the release-clm5.0 tag and create a
-new local branch (recommended). The destination of the `checkout` is a
+new local branch (recommended). The destination of the `clone` is a
 directory (e.g. ctsm\_fates\_emerald) in our home directory. From now on, we will call this directory `CTSM_ROOT`.
+
+You can export this path as a variable for easier access in your workspace:
+
+    [~/HOME]$ export CTSM_ROOT=${HOME}/ctsm_fates_emerald
 
 ### How to get a specific branch
 Change into the created ctsm directory
 
-    [~/HOME]$ cd ctsm_fates_emerald
+    [~/HOME]$ cd $CTSM_ROOT
 
 Check all existing branches
 
@@ -76,24 +80,24 @@ to function and include the version and your username, e.g.
 username\_fates\_emerald\_api. After checking out the externals, change
 to cime directory and create your own branch to record all your changes
 
-    [~/CTSM_ROOT]$ cd externals/cime
-    [~/CTSM_ROOT/externals/cime]$ git checkout -b username_cime
+    [~/CTSM_ROOT]$ cd cime
+    [~/CTSM_ROOT/cime]$ git checkout -b username_cime
 
 Change to fates directory and create your own branch to record all your
 changes
 
-    [~/CTSM_ROOT/externals/cime]$ cd ../externals/fates
-    [~/CTSM_ROOT/externals/fates]$ git checkout -b username_fates
+    [~/CTSM_ROOT/cime]$ cd ../src/fates
+    [~/CTSM_ROOT/fates]$ git checkout -b username_fates
 
 If you do not create your own branch for `cime` and `fates`, running
-`./manage_externals/checkout_externals`, will overwrite your
+`./manage_externals/checkout_externals` will overwrite your
 previous `cime` and `fates`. You should now be ready to create your
 first case.
 
 ### From the latest version of [CTSM](https://github.com/ESCOMP/CTSM)
 Start from your home folder and clone CTSM from ESCOMP 
 
-    [~/HOME]$ git clone --origin escomp <https://github.com/ESCOMP/CTSM.git> CTSM
+    [~/HOME]$ git clone --origin escomp https://github.com/ESCOMP/CTSM.git CTSM
 
 Change into the new directory
 
@@ -117,12 +121,11 @@ can be done in two ways (check the
 [original](https://esmci.github.io/cime/versions/master/html/users_guide/porting-cime.html#steps-for-porting)
 documentation for a detailed explanation):
 
-1. You can replace some default configuration files with configuration files that contain details for these clusters.
-2. You can create a **.cime** folder with the machine configurations under your home directory.
+##### 1) Replace the default configurations
 
-
-##### Replace the default configurations
+You can replace some default configuration files with configuration files that contain details for these clusters.
 Execute the following steps:
+
 1. Go into the cime-config folder
 
         [~/CTSM_ROOT]$ cd cime/config/cesm/machines
@@ -131,13 +134,16 @@ Execute the following steps:
 
         [~/CTSM_ROOT/cime/config/cesm/machine]$ rm config_machines.xml config_batch.xml config_compilers.xml
 
-3. Fetch replacementfiles from [this](https://github.com/gunnartl/config_files_sigma2.git) repository by typing
+3. Fetch replacement files from [this](https://github.com/gunnartl/config_files_sigma2.git) repository by typing
 
         [~/CTSM_ROOT/cime/config/cesm/machine]$ git init
-        [~/CTSM_ROOT/cime/config/cesm/machine]$ git remote add origin <https://github.com/gunnartl/config_files_sigma2.git>
+        [~/CTSM_ROOT/cime/config/cesm/machine]$ git remote add origin https://github.com/gunnartl/config_files_sigma2.git
         [~/CTSM_ROOT/cime/config/cesm/machine]$ git pull origin main
 
-##### Create a dotcime folder
+##### 2) Create a .cime folder
+
+You can create a **.cime** folder with the machine configurations under your home directory.
+
 Clone [this](https://github.com/MetOs-UiO/dotcime) repository and
 consult the `README.md` file for the details when making a new
 case.

--- a/content/index.rst
+++ b/content/index.rst
@@ -26,6 +26,7 @@ and NorESM's `documentation <https://noresm-docs.readthedocs.io/en/latest/config
    :maxdepth: 1
    :caption: Content
 
+   quick-start.md
    get.md
    run.md
    spinup.md

--- a/content/license.md
+++ b/content/license.md
@@ -5,7 +5,7 @@ The documentation on this webpage is made to help users of the clusters offered 
 ## Content 
 The information you can find here is maintained by CTSM-Norway-Team and is maintained as a collective effort. 
 
-The people that have contributed to the content of this webpage are (listed in alphabethical order): 
+The people that have contributed to the content of this webpage are (listed in alphabetical order): 
 
 [![](./img/profile_pictures/octocat.png)](https://github.com/ecaas) Elin Ristorp Aas
 

--- a/content/quick-start.md
+++ b/content/quick-start.md
@@ -1,0 +1,109 @@
+# Quick start
+
+This guide helps you set up your workspace and submit a case on FRAM machine. See the following sections for more details of how to get CTSM and create and submit cases.
+
+The guide works with ESCOMP CTSM v5.0.34. All commands should work as they are, so you can just copy and paste them into your terminal. If there's a parameter in a command wrapped in `<` and `>`, it means it should be replaced with your own values.
+
+## Create and run a case on FRAM:
+
+- If you don't already have a Sigma2 account, request one here (talk to your supervisor for project name to include in the application form): https://www.metacenter.no/user/application/.
+- After your account is activated, ssh into FRAM:
+
+    `ssh <your-sigma2-username>@fram.sigma2.no`.
+    ```{keypoints} Note
+    This command works on Linux and Mac systems.
+    For access on Windows see [here]((https://documentation.sigma2.no/getting_started/create_ssh_keys.html#login-via-ssh-keys)).
+    The link also has detailed description of ssh access for all systems.
+    ```
+- [*Optional*] Create a Workspace folder in your home directory and switch to it:
+
+    `mkdir ~/Workspace && cd ~/Workspace`.
+    ```{keypoints} Note
+    This step is optional, but the guide assumes you have created this folder and are working in it.
+    If you skip this, make sure to adjust any path that mentions `Workspace`.
+    ```
+- Clone [ESCOMP/CTSM](https://github.com/escomp/ctsm) into `~/Workspace/ctsm_escomp`:
+
+    `git clone https://github.com/escomp/ctsm ~/Workspace/ctsm_escomp`.
+- Go to the cloned repo:
+
+    `cd ~/Workspace/ctsm_escomp`.
+- Switch to `release-clm.5.0.34`:
+
+    `git fetch --all && git checkout release-clm.5.0.34`.
+- Edit `Externals.cfg` in the repo root and update the cime config section so it uses v5.6.10 by NorESMhub:
+
+    ```bash
+    sed -i 's/ESMCI/NorESMhub/' Externals.cfg
+    sed -i 's/cime5.6.33/cime5.6.10_cesm2_1_rel_06-Nor-dev/' Externals.cfg
+    ```
+
+    These commands should replace the cime config. Check the content of `Externals.cfg` with `cat Externals.cfg` to make sure cime config looks like:
+
+    ``` 
+    [cime] 
+    local_path = cime 
+    protocol = git 
+    repo_url = https://github.com/NorESMhub/cime 
+    tag = cime5.6.10_cesm2_1_rel_06-Nor-dev 
+    required = True 
+    ``` 
+- Get the external dependencies/repos:
+
+    `./manage_externals/checkout_externals`.
+- Adjust and export the following variables in your workspace:
+
+    ```bash
+    export CESM_ACCOUNT=nn2806k
+    export PROJECT=nn2806k
+    export CTSM_ROOT=/cluster/home/$USER/Workspace/ctsm_escomp
+    export CESM_DATA=/cluster/shared/noresm/inputdata
+    ```
+- Go to `cime/scripts/`:
+    `cd cime/script`
+- Run the following to create a new case:
+
+    `./create_newcase --case ~/Workspace/cases/I2000Clm50Sp --compset I2000Clm50Sp --res f19_g17 --machine fram --run-unsupported --project $CESM_ACCOUNT`.
+- If everything goes fine, there should be a new folder for your case in `~/Ẁorkspace/cases`. Switch to the case folder:
+
+    `cd ~/Workspace/cases/I2000Clm50Sp`.
+- Check that `DIN_LOC_ROOT_CLMFORC` is set to `/cluster/shared/noresm/inputdata/atm/datm7`:
+
+    `./xmlquery DIN_LOC_ROOT_CLMFORC`.
+- If the previous step returns `UNSET`, you can set `DIN_LOC_ROOT_CLMFORC` with `xmlchange`:
+
+    `./xmlchange DIN_LOC_ROOT_CLMFORC=/cluster/shared/noresm/inputdata/atm/datm7`.
+- Set up the case:
+
+    `./case.setup`.
+- Build the case:
+
+    `./case.build`.
+- Submit the case:
+
+    `./case.submit`.
+- If there's no error in the previous steps, there should be a line towards the end of `CaseStatus` file that contains `case.submit success`. You can check it with this:
+
+    `cat CaseStatus`.
+- If the submission is successful, your case goes in the execution queue. You can check the latest status in the same `CaseStatus` file. After a successful run, you should see messages like this:
+    ```
+    2022-01-25 12:00:22: case.submit starting 
+    ---------------------------------------------------
+    2022-01-25 12:00:31: case.submit success case.run:4020255, case.st_archive:4020256
+    ---------------------------------------------------
+    2022-01-25 12:00:32: case.run starting 
+    ---------------------------------------------------
+    2022-01-25 12:00:37: model execution starting 
+    ---------------------------------------------------
+    2022-01-25 12:01:31: model execution success 
+    ---------------------------------------------------
+    2022-01-25 12:01:31: case.run success 
+    ---------------------------------------------------
+    2022-01-25 12:01:34: st_archive starting 
+    ---------------------------------------------------
+    2022-01-25 12:01:45: st_archive success 
+    ---------------------------------------------------
+    ```
+- The last line means the execution was successful and the output is put in your user archive folder. You can see the output here:
+
+    `ls /cluster/work/users/$USER/archive/I2000Clm50Sp`.

--- a/content/run.md
+++ b/content/run.md
@@ -31,10 +31,21 @@ An example of environmental variables your might want to change are
     [~/HOME]$ export PROJECT=nn2806k
     [~/HOME]$ export CTSM_ROOT=/cluster/home/$USER/ctsm
 
-    [~/HOME]$ export INC_NETCDF=/cluster/software/VERSIONS/netcdf.intel-4.3.3.1/
-    [~/HOME]$ export LIB_NETCDF=/cluster/software/VERSIONS/netcdf.intel-4.3.3.1/
-    [~/HOME]$ export NETCDF_ROOT=/cluster/software/VERSIONS/netcdf.intel-4.3.3.1/
+    [~/HOME]$ export INC_NETCDF=/cluster/software/netCDF/4.4.0-intel-2016a/
+    [~/HOME]$ export LIB_NETCDF=/cluster/software/netCDF/4.4.0-intel-2016a/
+    [~/HOME]$ export NETCDF_ROOT=/cluster/software/netCDF/4.4.0-intel-2016a/
 
+You can store all these variables in a shell script file and enable them in your workspace by sourcing that file.
+E.g. create a file in `~/Workspace/scripts/` called `ctsm_setup.sh` with the following content:
+
+```
+export CESM_ACCOUNT=nn2806k
+export PROJECT=nn2806k
+export CTSM_ROOT=/cluster/home/$USER/Workspace/ctsm
+export CESM_DATA=/cluster/shared/noresm/inputdata
+```
+
+You can now run `source ~/Workspace/scripts/ctsm_setup.sh` to activate all these variables.
 
 ## Your first CTSM case
 
@@ -49,16 +60,9 @@ If you are doing changes to the code, remember to create your own branches for t
 
     [~/CTSM_ROOT]$ ./manage_externals/checkout_externals
 
-Read more about how manage_externals/checkout_externals work [here](https://github.com/ESMCI/manage_externals).
+Read more about how `manage_externals/checkout_externals` work [here](https://github.com/ESMCI/manage_externals).
 
 ```
-
-
-### The input data directory
-The first time, or whenever your `$WORKDIR` is cleaned, you need to link your working directory with your input data
-
-    [~/CTSM_ROOT]$ cd cime/scripts
-    [~/CTSM_ROOT/cime/scripts]$ ./link_dirtree $CESM_DATA /work/users/$USER/inputdata
 
 ### Create a case
 Before you can run the model you must create a new case. 
@@ -133,9 +137,14 @@ CLM supports running single-point simulations. Available options are summarized 
 For testing purpose, we recommend running a single point using global data, i.e., [PTS_MODE](https://escomp.github.io/ctsm-docs/versions/master/html/users_guide/running-single-points/running-pts_mode-configurations.html#running-a-single-point-using-global-data-pts-mode). Below we show you how to create a single-point case using global data.
 
     [~/CTSM_ROOT/cime/scripts]$ export CESM_ACCOUNT=nn2806k
-    [~/CTSM_ROOT/cime/scripts]$ ./create_newcase -case ~/cases/testPTS_MODE --res f19_g17_gl4 --compset I2000Clm50SpGs -pts_lat 40.0 -pts_lon -105 --machine saga --run-unsupported --project $CESM_ACCOUNT
+    [~/CTSM_ROOT/cime/scripts]$ ./create_newcase --case ~/cases/testPTS_MODE --res f19_g17_gl4 --compset I1850Clm50BgcCropCru --machine saga --run-unsupported --project $CESM_ACCOUNT
 
-For dedicated single-cell simulation in order to compare with site-level observation data, we recommend running single-cell simulation using your own datasets following the examples (1.6.3.4 - 1.6.3.6) from [ESCOMP guide] (https://escomp.github.io/ctsm-docs/versions/master/html/users_guide/running-single-points/running-single-point-configurations.html#example-using-clm-usrdat-name-to-run-a-simulation-using-user-datasets-for-a-specific-region-over-alaska) 
+Now go to the new case folder and update the point latitude and longitude:
+
+    [~/cases/testPTS_MODE] ./xmlchange PTS_LAT=40.0
+    [~/cases/testPTS_MODE] ./xmlchange PTS_LON=-105
+
+For dedicated single-cell simulation in order to compare with site-level observation data, we recommend running single-cell simulation using your own datasets following the examples (1.6.3.4 - 1.6.3.6) from [ESCOMP guide](https://escomp.github.io/ctsm-docs/versions/master/html/users_guide/running-single-points/running-single-point-configurations.html#example-using-clm-usrdat-name-to-run-a-simulation-using-user-datasets-for-a-specific-region-over-alaska).
 
 There are dedicated tools and workflow for running single-cell simulations over Norwegian ecological observation sites using CLM and CLM-FATES, please check [NorESM_LandSites_Platform](https://github.com/NorESMhub/NorESM_LandSites_Platform) and follow the instructions there.
 
@@ -143,7 +152,7 @@ There are dedicated tools and workflow for running single-cell simulations over 
 Follow the below procedure to run CTSM over a specific region of interest for a specific resolution. 
 
 ### Domain and surface data
-To run over the Scandinavia region (latitude 48N to 81N, longitude 4E to 42E) at 0.5 degree resolution you first need to produce the domain and surface data files for the region using the python script `subset_data.py` available under the CTSM tools directory `CTSM_ROOT/tools/contrib/subset_data.py`. The python script file can be found [here](https://github.com/ESCOMP/CTSM/blob/master/tools/site_and_regional/subset_data.py). 
+To run over the Scandinavia region (latitude 48N to 81N, longitude 4E to 42E) at 0.5 degree resolution you first need to produce the domain and surface data files for the region using the python script `subset_data.py` available under the CTSM tools directory `CTSM_ROOT/tools/site_and_regional/subset_data.py`. The python script file can be found [here](https://github.com/ESCOMP/CTSM/blob/master/tools/site_and_regional/subset_data.py). 
 
 The python scripts requires input arguments corresponding to your region of interest. Command below helps you to understand on how to provide
 input argument variables:
@@ -157,7 +166,7 @@ First, you need to change the global input data directory variable inside the sc
 Choose a location for storing the domain and surface data files for Scandinavia (eg. /cluster/projects/nn2806k/$USER/regiondata). 
 Set the environment variable for the directory as below:
 
-    MYREGDATA='/cluster/projects/nn2806k/$USER/regiondata/'
+    MYREGDATA=/cluster/projects/nn2806k/$USER/regiondata/
 
 ```{discussion} Choose the global surface data file corresponding to the resolution! 
 For example: for 0.5x0.5 resolution, choose `surfdata_360x720cru_16pfts_Irrig_CMIP6_simyr2000_c170824.nc` (under shared noresm folder)


### PR DESCRIPTION
This PR adds a new quick start page. The purpose of this page is to help users set up and submit a case without going into details of the commands.

I also updated parts of the docs based on the latest changes in CTSM and CIME.